### PR TITLE
Harden PortfolioInvestmentProblem defaults and add regression tests

### DIFF
--- a/cifo/custom_problem/portfolio_investment_problem.py
+++ b/cifo/custom_problem/portfolio_investment_problem.py
@@ -78,7 +78,7 @@ class PortfolioInvestmentProblem( ProblemTemplate ):
 
         
         if "stdiv" in decision_variables[0]:
-            self._stdivs = decision_variables[0]["stock_name"]
+            self._stdivs = decision_variables[0]["stdiv"]
 
         
         if len(decision_variables) == 2:
@@ -99,9 +99,10 @@ class PortfolioInvestmentProblem( ProblemTemplate ):
         if "Optimum_num" in constraints:
             self._optimum_stocks = constraints["Optimum_num"]
         else:
-            self._optimum_value = len(self._stocks)
+            self._optimum_stocks = len(self._stocks)
         
 
+        encoding_rule = deepcopy(encoding_rule)
         encoding_rule["Size"] = len( self._stocks )
         #print(encoding_rule["Size"])
         encoding_rule["Data"] = list(range(0,10))
@@ -147,7 +148,7 @@ class PortfolioInvestmentProblem( ProblemTemplate ):
         for i in takewhile(lambda i:i<stock_counter and solution_investment<self._max_investment*(1-tolerance), count()):
             n = choice(self._encoding_rule['Data'])
             solution_representation[randint(0,len(solution_representation)-1)] = n
-            solution_investment += cal_total_investment(solution_representation)
+            solution_investment = cal_total_investment(solution_representation)
             i+=1
 
         solution = LinearSolution(
@@ -292,6 +293,10 @@ class PortfolioInvestmentProblem( ProblemTemplate ):
         total_weight = sum(stocks_picked)
         fitness = 0
 
+        if total_weight == 0:
+            solution.fitness = fitness
+            return solution
+
         for i in range(0, len( stocks_picked )):
             if stocks_picked[ i ] >= 1:
                 fitness += round((stocks_picked[ i ]/ total_weight)*(self._exp_rets[ i ])/100,2)#need to check this
@@ -304,10 +309,8 @@ class PortfolioInvestmentProblem( ProblemTemplate ):
 
             dict_toWrite = {'fitness': solution.fitness,
                             'stocks': solution.representation}
-            f = open('stocks-PIP_PMX-09_Inv-09_RankS-15_p-20_I-1000.txt', "w+")
-            
-            f.write('stocks: ' + repr(dict_toWrite) + '\n')
-            f.close()
+            with open('stocks-PIP_PMX-09_Inv-09_RankS-15_p-20_I-1000.txt', "w+") as f:
+                f.write('stocks: ' + repr(dict_toWrite) + '\n')
 
         
         return solution      

--- a/tests/test_portfolio_investment_problem.py
+++ b/tests/test_portfolio_investment_problem.py
@@ -1,0 +1,52 @@
+import pandas as pd
+
+from cifo.custom_problem.portfolio_investment_problem import (
+    PortfolioInvestmentProblem,
+    pip_encoding_rule,
+)
+from cifo.problem.solution import LinearSolution
+
+
+def _problem(**constraints):
+    decision_variables = [
+        {
+            "stock": ["AAA", "BBB"],
+            "stock_name": ["A", "B"],
+            "price": [10, 20],
+            "exp_ret": [5, 10],
+            "stdiv": [0.1, 0.2],
+        },
+        pd.DataFrame({"AAA": [1.0, 1.1, 1.2], "BBB": [2.0, 2.2, 2.4]}),
+    ]
+    base_constraints = {
+        "Risk-free-rate": 0,
+        "Max-Investment": 1000,
+        "Risk-Tolerance": 0,
+    }
+    base_constraints.update(constraints)
+    return PortfolioInvestmentProblem(decision_variables, base_constraints)
+
+
+def test_default_optimum_stock_count_uses_all_stocks():
+    problem = _problem()
+
+    assert problem._optimum_stocks == 2
+
+
+def test_portfolio_problem_does_not_mutate_default_encoding_rule():
+    original_size = pip_encoding_rule["Size"]
+    original_data = list(pip_encoding_rule["Data"])
+
+    _problem()
+
+    assert pip_encoding_rule["Size"] == original_size
+    assert pip_encoding_rule["Data"] == original_data
+
+
+def test_evaluate_solution_handles_zero_weight_portfolio():
+    problem = _problem()
+    solution = LinearSolution([0, 0], problem.encoding_rule)
+
+    evaluated = problem.evaluate_solution(solution)
+
+    assert evaluated.fitness == 0


### PR DESCRIPTION
### Motivation
- Fix several robustness and correctness issues in `PortfolioInvestmentProblem` so per-instance defaults are safe and evaluation is stable for edge cases.
- Prevent accidental mutation of the module-level encoding rule which caused instance-specific changes to leak into the global default.
- Add regression tests to lock in the intended behaviors and prevent regressions.

### Description
- Corrected the `stdiv` initialization in `cifo/custom_problem/portfolio_investment_problem.py` so `_stdivs` is assigned from the `stdiv` key instead of the wrong field.
- Use `deepcopy` on the incoming `encoding_rule` before modifying `Size` and `Data` to avoid mutating the module-level `pip_encoding_rule` default.
- Fix solution construction so `solution_investment` is recalculated each iteration (replaces a compounding-add bug) and ensure the fallback `Optimum_num` uses `self._optimum_stocks = len(self._stocks)`.
- Harden `evaluate_solution` to handle zero-weight portfolios safely (returns fitness 0 immediately) and use a context manager for writing the best-solution output file.
- Add regression tests `tests/test_portfolio_investment_problem.py` covering default optimum stock count, immutability of the default encoding rule, and evaluation of a zero-weight portfolio.

### Testing
- Ran `python -m compileall cifo` which succeeded and verified the modified modules compile without syntax errors.
- Running `pytest -q` initially failed because the package was not importable without setting `PYTHONPATH` in the environment; setting `PYTHONPATH=.` was used for targeted runs.
- Running `PYTHONPATH=. pytest -q tests/test_portfolio_investment_problem.py` was blocked by a missing runtime dependency (`pandas`) in the current Python 3.14 environment, so the new tests could not be executed here.
- The change set includes the new tests and is ready for CI where dependencies (notably `pandas`) are available so the regression tests can run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_687fd7ace8688332a8a91bf9f0bccb15)